### PR TITLE
Remove Travis build status from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Apache Fineract CN Identity Manager [![Build Status](https://api.travis-ci.com/apache/fineract-cn-identity.svg?branch=develop)](https://travis-ci.com/apache/fineract-cn-identity)  [![Docker Cloud Build Status](https://img.shields.io/docker/cloud/build/apache/fineract-cn-identity)](https://hub.docker.com/r/apache/fineract-cn-identity/builds)
+# Apache Fineract CN Identity Manager [![Docker Cloud Build Status](https://img.shields.io/docker/cloud/build/apache/fineract-cn-identity)](https://hub.docker.com/r/apache/fineract-cn-identity/builds)
 
 This project provides identity management for Apache Fineract CN services.
 [Read more](https://cwiki.apache.org/confluence/display/FINERACT/Fineract+CN+Project+Structure#FineractCNProjectStructure-identity).


### PR DESCRIPTION
Due to the removal of the Travis build scripts from the project. The build status in the README.md is now misleading and needs to be removed.